### PR TITLE
Add test vault and development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,35 @@ I am an idependent software developer. If you find Co-Intelligence to be useful,
 
 [<img style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' />](https://ko-fi.com/X8X71G7YSI)
 
+## Development
+
+### Setup
+
+```bash
+npm install
+npm run dev      # Watch mode — rebuilds on file changes
+npm run build    # Production build (also validates TypeScript types)
+npm test         # Run tests with Vitest
+```
+
+### Manual Testing
+
+A test vault is included at `test-vault/` so you can test the plugin in Obsidian without affecting your personal vault. To build and open it:
+
+```bash
+./scripts/open-test-vault.sh
+```
+
+The first time you open the vault, you'll need to enable community plugins in Settings > Community plugins. After that, the Co-Intelligence AI plugin will be pre-enabled.
+
+The script symlinks the build output (`dist/`) into the test vault's plugin directory, so rebuilds are picked up automatically. For a live development workflow:
+
+1. Run `npm run dev` in one terminal
+2. Run `./scripts/open-test-vault.sh` to open the vault
+3. After changes rebuild, reload Obsidian (Cmd/Ctrl+P > "Reload app without saving")
+
+The test vault includes sample folders and system prompts for exercising plugin features.
+
 ## Contributing, Feedback, and Help
 
 This is an open source project, using the [MIT License](LICENSE). Pull requests for bug fixes or small improvements are welcome. If you want to get involved in a more substantial way, please [Contact me](https://epistemic.technology/contact/).

--- a/scripts/open-test-vault.sh
+++ b/scripts/open-test-vault.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+VAULT_DIR="$PROJECT_DIR/test-vault"
+PLUGIN_DIR="$VAULT_DIR/.obsidian/plugins/co-intelligence"
+
+# Create plugin directory and symlinks
+mkdir -p "$PLUGIN_DIR"
+ln -sf "$PROJECT_DIR/dist/main.js" "$PLUGIN_DIR/main.js"
+ln -sf "$PROJECT_DIR/dist/styles.css" "$PLUGIN_DIR/styles.css"
+ln -sf "$PROJECT_DIR/manifest.json" "$PLUGIN_DIR/manifest.json"
+
+# Build latest
+echo "Building plugin..."
+npm --prefix "$PROJECT_DIR" run build
+
+# Open the test vault in Obsidian
+echo "Opening test vault in Obsidian..."
+open "obsidian://open?path=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$VAULT_DIR'))")"
+
+echo "Done. If this is the first time, enable the plugin in Settings > Community plugins."

--- a/test-vault/.gitignore
+++ b/test-vault/.gitignore
@@ -1,0 +1,7 @@
+# Obsidian generates config files when the vault is opened.
+# Only community-plugins.json is checked in (to pre-enable the plugin).
+.obsidian/*
+!.obsidian/community-plugins.json
+
+# Plugin symlinks are machine-specific; the script recreates them.
+.obsidian/plugins/

--- a/test-vault/.obsidian/community-plugins.json
+++ b/test-vault/.obsidian/community-plugins.json
@@ -1,0 +1,1 @@
+["co-intelligence"]

--- a/test-vault/coi/prompts/Code reviewer.md
+++ b/test-vault/coi/prompts/Code reviewer.md
@@ -1,0 +1,1 @@
+You are a code reviewer. Review code for bugs, style issues, and potential improvements. Be constructive and specific.

--- a/test-vault/coi/prompts/Helpful assistant.md
+++ b/test-vault/coi/prompts/Helpful assistant.md
@@ -1,0 +1,1 @@
+You are a helpful assistant. Be concise and clear in your responses.

--- a/test-vault/notes/Sample note.md
+++ b/test-vault/notes/Sample note.md
@@ -1,0 +1,13 @@
+This is a sample note for testing context linking in Co-Intelligence AI.
+
+## Key points
+
+- First point with **bold** and *italic* formatting
+- Second point with a `code snippet`
+- Third point with a [[link to nowhere]]
+
+```javascript
+function hello() {
+  console.log("Hello from a code block");
+}
+```


### PR DESCRIPTION
## Summary

- Add a test vault (`test-vault/`) with sample folders, system prompts, and notes for manual plugin testing
- Add `scripts/open-test-vault.sh` — builds the plugin, symlinks output into the test vault, and opens it in Obsidian
- Add a Development section to the README documenting setup, manual testing, and live dev workflow

## Test plan

- [ ] Run `./scripts/open-test-vault.sh` and verify the vault opens in Obsidian
- [ ] Enable community plugins, confirm Co-Intelligence AI appears and loads
- [ ] Verify sample prompts and notes are present in the vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)