### PR TITLE
Fix streaming broken by AI SDK v6 chunk type changes

### DIFF
--- a/src/components/BotMessage.tsx
+++ b/src/components/BotMessage.tsx
@@ -14,7 +14,7 @@ export const BotMessage: Component<BotMessageProps> = ({
 }: BotMessageProps) => {
   const file = useContext(FileContext);
   const filePath = file?.path || "";
-  const content = message.content as string;
+  const content = (message.content as string) ?? "";
   // Perplexity models use <think> tags to indicate the reasoning section.
   // OpenAI models use chunk types instead. These are translated into <think>
   // tags by handleSendMessage in ChatInterface.tsx

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -176,28 +176,31 @@ export const ChatInterface = ({
             console.log("Error:", chunk.error);
             new Notice("Unknown error occurred. See console log for details.");
           }
-          if (chunk.type !== "text-delta" && chunk.type !== "reasoning") {
+          if (chunk.type === "reasoning-start") {
+            doingReasoning = true;
+            accumulatedContent += "<think>";
             continue;
           }
+          if (chunk.type === "reasoning-end") {
+            doingReasoning = false;
+            accumulatedContent += "</think>";
+            continue;
+          }
+          if (chunk.type !== "text-delta" && chunk.type !== "reasoning-delta") {
+            continue;
+          }
+          const text = chunk.text;
           if (isFirstChunk) {
             const assistantMessage: ModelChatMessage = {
               role: "assistant",
-              content: chunk.textDelta,
+              content: text,
             };
             setMessages([...messages(), assistantMessage]);
-            if (chunk.type === "reasoning") {
-              accumulatedContent = "<think>";
-              doingReasoning = true;
-            }
-            accumulatedContent += chunk.textDelta;
+            accumulatedContent += text;
             isFirstChunk = false;
             setIsProcessing(false);
           } else {
-            if (doingReasoning && chunk.type !== "reasoning") {
-              accumulatedContent += "</think>";
-              doingReasoning = false;
-            }
-            accumulatedContent += chunk.textDelta;
+            accumulatedContent += text;
             setMessages((prevMessages) => {
               const updatedMessages = [...prevMessages];
               updatedMessages[updatedMessages.length - 1] = {
@@ -246,7 +249,7 @@ export const ChatInterface = ({
 
         // Replace source reference numbers [n] with [n+offset]
         const offset = lastSourceLinkNumber();
-        const updatedContent = (lastMessage.content as string).replace(
+        const updatedContent = ((lastMessage.content as string) ?? "").replace(
           /\[(\d+)\]/g,
           (match, num) => {
             const source = uniqueNewSources[parseInt(num) - 1];
@@ -274,7 +277,9 @@ export const ChatInterface = ({
       if (!hasProcessedSources) {
         const currentMessage = messages()[messages().length - 1];
         const newLinks =
-          (currentMessage.content as string).match(/\[(.*?)\]\((.*?)\)/g) || [];
+          ((currentMessage.content as string) ?? "").match(
+            /\[(.*?)\]\((.*?)\)/g,
+          ) || [];
         newLinks.forEach((link) => {
           const [text, url] = link.slice(1, -1).split("](");
           const existingSource = sources().find((source) => source.url === url);

--- a/src/utils/notes.ts
+++ b/src/utils/notes.ts
@@ -189,7 +189,7 @@ export async function serializeCoiNoteContent(
 ): Promise<string> {
   const serializedMessages = messages
     .map(({ role, content }) => {
-      const contentStr = content as string;
+      const contentStr = (content as string) ?? "";
 
       // Find the highest level header in the content
       const headerMatches = contentStr.match(/^#+/gm);


### PR DESCRIPTION
## Summary
- AI SDK v6 renamed `fullStream` chunk properties (`textDelta` → `text`) and split the `reasoning` chunk type into `reasoning-start`/`reasoning-delta`/`reasoning-end`. The old property names returned `undefined`, causing `TypeError` crashes in message rendering (`.indexOf()`) and serialization (`.match()`).
- Adds nullish coalescing fallbacks on unsafe `content as string` casts in `BotMessage`, `ChatInterface`, and `notes.ts`.

## Test plan
- [x] `npm run build` passes
- [x] All 106 tests pass
- [x] Manually verify chat streaming works with text-only models
- [x] Manually verify reasoning models (e.g. o3, Claude with extended thinking) show thinking section correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)