### PR TITLE
Phase 3 vertical slice: read_note tool + tool runtime wiring

### DIFF
--- a/src/CoIntelligencePlugin.tsx
+++ b/src/CoIntelligencePlugin.tsx
@@ -26,6 +26,14 @@ import { CoiNoteFrontmatter } from "@/types";
 import "@/types-extended";
 
 import {
+    createPermissionBroker,
+    type PermissionBroker,
+} from "@/agent/permission-broker";
+import { mountApprovalModalBroker } from "@/agent/approval/obsidian-modal-broker";
+import { createDefaultToolRegistry } from "@/agent/tools";
+import type { ToolRegistry } from "@/agent/tool-registry";
+
+import {
     isCoiNote,
     isPathActiveCoiNote,
     createCOINote,
@@ -36,6 +44,9 @@ import {
 export class CoIntelligencePlugin extends Plugin {
     settings: CoIntelligenceSettings;
     registry: ModelRegistry | undefined;
+    tools: ToolRegistry | undefined;
+    permissionBroker: PermissionBroker | undefined;
+    private disposeApprovalModal: (() => void) | null = null;
     public isPerformingAutomaticRename: boolean = false;
 
     constructor(app: App, manifest: PluginManifest) {
@@ -46,6 +57,15 @@ export class CoIntelligencePlugin extends Plugin {
     async onload() {
         await this.loadSettings();
         this.registry = ModelRegistry.getInstance(this);
+        this.tools = createDefaultToolRegistry({
+            app: this.app,
+            plugin: this,
+        });
+        this.permissionBroker = createPermissionBroker();
+        this.disposeApprovalModal = mountApprovalModalBroker(
+            this.permissionBroker,
+            this.app,
+        );
         this.addSettingTab(new CoIntelligenceSettingsTab(this.app, this));
         this.addCommand(new NewChatCommand(this));
         this.addCommand(new ToggleChatViewCommand(this));
@@ -75,6 +95,16 @@ export class CoIntelligencePlugin extends Plugin {
 
     onloadOnLayoutReady() {
         this.registerMonkeyPatches();
+    }
+
+    onunload(): void {
+        if (this.disposeApprovalModal) {
+            this.disposeApprovalModal();
+            this.disposeApprovalModal = null;
+        }
+        if (this.permissionBroker) {
+            this.permissionBroker.clear();
+        }
     }
 
     private handleFileOpen(_file: TFile | null): void {}

--- a/src/agent/__tests__/tool-registry.test.ts
+++ b/src/agent/__tests__/tool-registry.test.ts
@@ -1,7 +1,21 @@
 import { describe, it, expect, vi } from "vitest";
+import { App } from "obsidian";
+import { createRoot } from "solid-js";
 import { z } from "zod";
-import { createToolRegistry } from "@/agent/tool-registry";
-import type { CoiTool } from "@/agent/types";
+import {
+    createToolRegistry,
+    ToolApprovalDeniedError,
+} from "@/agent/tool-registry";
+import { createPermissionBroker } from "@/agent/permission-broker";
+import type CoIntelligencePlugin from "@/CoIntelligencePlugin";
+import type { CoiTool, ToolDependencies } from "@/agent/types";
+
+function makeDeps(): ToolDependencies {
+    return {
+        app: new App(),
+        plugin: {} as CoIntelligencePlugin,
+    };
+}
 
 function makeTool(
     overrides: Partial<CoiTool<unknown, unknown>> & { name: string },
@@ -84,7 +98,8 @@ describe("createToolRegistry", () => {
     });
 
     it("toAiSdkTools wraps execute to receive toolCallId + abortSignal", async () => {
-        const registry = createToolRegistry();
+        const deps = makeDeps();
+        const registry = createToolRegistry(deps);
         const execute = vi.fn(async () => "ok");
         registry.register(
             makeTool({ name: "echo", execute: execute as never }),
@@ -100,16 +115,126 @@ describe("createToolRegistry", () => {
         expect(result).toBe("ok");
         expect(execute).toHaveBeenCalledWith(
             { q: 1 },
-            { toolCallId: "call-1", abortSignal },
+            { ...deps, toolCallId: "call-1", abortSignal },
         );
     });
 
-    it("toAiSdkTools forwards requiresApproval as needsApproval", () => {
-        const registry = createToolRegistry();
-        registry.register(makeTool({ name: "destructive", requiresApproval: true }));
-        registry.register(makeTool({ name: "safe", requiresApproval: false }));
+    it("approval-required tools call the broker before executing", async () => {
+        const registry = createToolRegistry(makeDeps());
+        const execute = vi.fn(async () => "ran");
+        registry.register(
+            makeTool({
+                name: "edit_note",
+                requiresApproval: true,
+                execute: execute as never,
+            }),
+        );
+        const { result, broker } = await new Promise<{
+            result: unknown;
+            broker: ReturnType<typeof createPermissionBroker>;
+        }>((resolve) => {
+            createRoot(() => {
+                const broker = createPermissionBroker();
+                const set = registry.toAiSdkTools({ permissionBroker: broker });
+                const pending = (
+                    set.edit_note.execute as unknown as (
+                        input: unknown,
+                        opts: { toolCallId: string },
+                    ) => Promise<unknown>
+                )({ path: "a.md" }, { toolCallId: "c1" });
+                queueMicrotask(() => {
+                    broker.resolve("c1", "allow");
+                    void pending.then((result) => resolve({ result, broker }));
+                });
+            });
+        });
+        expect(result).toBe("ran");
+        expect(execute).toHaveBeenCalledOnce();
+        expect(broker.pending()).toEqual([]);
+    });
+
+    it("approval-required tools throw when broker denies", async () => {
+        const registry = createToolRegistry(makeDeps());
+        const execute = vi.fn(async () => "ran");
+        registry.register(
+            makeTool({
+                name: "edit_note",
+                requiresApproval: true,
+                execute: execute as never,
+            }),
+        );
+        const error = await new Promise<unknown>((resolve) => {
+            createRoot(() => {
+                const broker = createPermissionBroker();
+                const set = registry.toAiSdkTools({ permissionBroker: broker });
+                const pending = (
+                    set.edit_note.execute as unknown as (
+                        input: unknown,
+                        opts: { toolCallId: string },
+                    ) => Promise<unknown>
+                )({}, { toolCallId: "c1" });
+                queueMicrotask(() => {
+                    broker.resolve("c1", "deny");
+                    pending.then(
+                        () => resolve(new Error("did not throw")),
+                        (err) => resolve(err),
+                    );
+                });
+            });
+        });
+        expect(error).toBeInstanceOf(ToolApprovalDeniedError);
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("approval-required tools run unconditionally when no broker is provided", async () => {
+        const registry = createToolRegistry(makeDeps());
+        const execute = vi.fn(async () => "ran");
+        registry.register(
+            makeTool({
+                name: "edit_note",
+                requiresApproval: true,
+                execute: execute as never,
+            }),
+        );
         const set = registry.toAiSdkTools();
-        expect((set.destructive as { needsApproval?: boolean }).needsApproval).toBe(true);
-        expect((set.safe as { needsApproval?: boolean }).needsApproval).toBe(false);
+        const result = await (
+            set.edit_note.execute as unknown as (
+                input: unknown,
+                opts: { toolCallId: string },
+            ) => Promise<unknown>
+        )({}, { toolCallId: "c1" });
+        expect(result).toBe("ran");
+        expect(execute).toHaveBeenCalledOnce();
+    });
+
+    it("approval-not-required tools bypass the broker", async () => {
+        const registry = createToolRegistry(makeDeps());
+        const execute = vi.fn(async () => "ran");
+        registry.register(
+            makeTool({
+                name: "read_note",
+                requiresApproval: false,
+                execute: execute as never,
+            }),
+        );
+        const { result, broker } = await new Promise<{
+            result: unknown;
+            broker: ReturnType<typeof createPermissionBroker>;
+        }>((resolve) => {
+            createRoot(() => {
+                const broker = createPermissionBroker();
+                const set = registry.toAiSdkTools({ permissionBroker: broker });
+                void (
+                    set.read_note.execute as unknown as (
+                        input: unknown,
+                        opts: { toolCallId: string },
+                    ) => Promise<unknown>
+                )({}, { toolCallId: "c1" }).then((result) =>
+                    resolve({ result, broker }),
+                );
+            });
+        });
+        expect(result).toBe("ran");
+        expect(broker.pending()).toEqual([]);
     });
 });

--- a/src/agent/approval/obsidian-modal-broker.ts
+++ b/src/agent/approval/obsidian-modal-broker.ts
@@ -1,0 +1,126 @@
+import { App, Modal } from "obsidian";
+import { createEffect, createRoot } from "solid-js";
+
+import type {
+    ApprovalDecision,
+    PendingApproval,
+    PermissionBroker,
+} from "@/agent/permission-broker";
+
+/**
+ * Renders an Obsidian {@link Modal} for each pending approval emitted by the
+ * broker. Interim Phase 3 UI — replaced in Phase 5 by an in-chat approval card
+ * (issue #66). The modal is intentionally minimal: tool name, JSON args, and
+ * three buttons (allow / deny / always).
+ *
+ * Returns a dispose function that tears down both the Solid root and any open
+ * modal. Safe to call on plugin unload.
+ */
+export function mountApprovalModalBroker(
+    broker: PermissionBroker,
+    app: App,
+): () => void {
+    const seen = new Set<string>();
+    let activeModal: ToolApprovalModal | null = null;
+
+    return createRoot((dispose) => {
+        createEffect(() => {
+            const queue = broker.pending();
+            for (const entry of queue) {
+                if (seen.has(entry.toolCallId)) continue;
+                seen.add(entry.toolCallId);
+                openOne(entry);
+            }
+        });
+
+        return () => {
+            if (activeModal) {
+                activeModal.close();
+                activeModal = null;
+            }
+            seen.clear();
+            dispose();
+        };
+    });
+
+    function openOne(entry: PendingApproval) {
+        const modal = new ToolApprovalModal(app, entry, (decision) => {
+            broker.resolve(entry.toolCallId, decision);
+            if (activeModal === modal) {
+                activeModal = null;
+            }
+        });
+        activeModal = modal;
+        modal.open();
+    }
+}
+
+class ToolApprovalModal extends Modal {
+    private readonly entry: PendingApproval;
+    private readonly onDecision: (decision: ApprovalDecision) => void;
+    private decided = false;
+
+    constructor(
+        app: App,
+        entry: PendingApproval,
+        onDecision: (decision: ApprovalDecision) => void,
+    ) {
+        super(app);
+        this.entry = entry;
+        this.onDecision = onDecision;
+    }
+
+    onOpen(): void {
+        const { titleEl, contentEl } = this;
+        titleEl.setText(`Approve tool: ${this.entry.toolName}`);
+
+        const desc = contentEl.createEl("p", {
+            text: "The assistant wants to run the following tool. Review the arguments before allowing.",
+        });
+        desc.addClass("coi-approval-desc");
+
+        const argsEl = contentEl.createEl("pre");
+        argsEl.addClass("coi-approval-args");
+        argsEl.setText(formatInput(this.entry.input));
+
+        const buttons = contentEl.createEl("div");
+        buttons.addClass("coi-approval-buttons");
+
+        this.addButton(buttons, "Deny", "deny");
+        this.addButton(buttons, "Allow", "allow");
+        this.addButton(buttons, "Always allow", "always");
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+        if (!this.decided) {
+            this.decided = true;
+            this.onDecision("deny");
+        }
+    }
+
+    private addButton(
+        parent: HTMLElement,
+        label: string,
+        decision: ApprovalDecision,
+    ): void {
+        const btn = parent.createEl("button", { text: label });
+        if (decision === "allow") {
+            btn.addClass("mod-cta");
+        }
+        btn.addEventListener("click", () => {
+            if (this.decided) return;
+            this.decided = true;
+            this.onDecision(decision);
+            this.close();
+        });
+    }
+}
+
+function formatInput(input: unknown): string {
+    try {
+        return JSON.stringify(input, null, 2);
+    } catch {
+        return String(input);
+    }
+}

--- a/src/agent/tool-registry.ts
+++ b/src/agent/tool-registry.ts
@@ -1,29 +1,64 @@
 import { tool as aiTool, type ToolSet } from "ai";
-import type { CoiTool, ToolPlatform, ToolScope } from "@/agent/types";
+import type {
+    CoiTool,
+    ToolDependencies,
+    ToolPlatform,
+    ToolScope,
+} from "@/agent/types";
+import type { PermissionBroker } from "@/agent/permission-broker";
 
 export interface ToolRegistryFilter {
     platform?: ToolPlatform;
     scope?: ToolScope;
 }
 
+export interface ToAiSdkToolsOptions extends ToolRegistryFilter {
+    /**
+     * When set, approval-required tools are gated through the broker inside
+     * the execute wrapper. A `"deny"` decision throws — surfaced to the model
+     * as a `tool-error` event. Without a broker, approval-required tools run
+     * unconditionally (intended only for tests / non-interactive contexts).
+     */
+    permissionBroker?: PermissionBroker;
+}
+
 export interface ToolRegistry {
-    register(tool: CoiTool): void;
+    register<I, O>(tool: CoiTool<I, O>): void;
     has(name: string): boolean;
     get(name: string): CoiTool | undefined;
     list(filter?: ToolRegistryFilter): CoiTool[];
     /**
      * Converts the matching tools into the AI SDK `ToolSet` shape that
      * `streamText` accepts. The execute wrapper forwards the AI SDK's
-     * toolCallId / abortSignal to the Coi tool.
+     * toolCallId / abortSignal to the Coi tool, and (when a broker is
+     * supplied) gates approval-required tools before invoking the underlying
+     * execute.
      */
-    toAiSdkTools(filter?: ToolRegistryFilter): ToolSet;
+    toAiSdkTools(options?: ToAiSdkToolsOptions): ToolSet;
+}
+
+/**
+ * Thrown by the execute wrapper when the permission broker resolves an
+ * approval-required tool call with `"deny"`. The AI SDK surfaces this as a
+ * `tool-error` chunk; the controller then writes a denied tool-result part
+ * into the session so the model can react in the next step.
+ */
+export class ToolApprovalDeniedError extends Error {
+    constructor(toolName: string) {
+        super(`Tool call "${toolName}" was denied by the user`);
+        this.name = "ToolApprovalDeniedError";
+    }
 }
 
 /**
  * Creates an empty tool registry. Append-only: re-registering an existing name
- * throws to surface accidental collisions early.
+ * throws to surface accidental collisions early. The optional `dependencies`
+ * are merged into every tool's execution context — pass them once at plugin
+ * load so tool implementations don't need their own access to `app` / `plugin`.
  */
-export function createToolRegistry(): ToolRegistry {
+export function createToolRegistry(
+    dependencies?: ToolDependencies,
+): ToolRegistry {
     const tools = new Map<string, CoiTool>();
 
     const filtered = (filter?: ToolRegistryFilter): CoiTool[] => {
@@ -45,7 +80,7 @@ export function createToolRegistry(): ToolRegistry {
             if (tools.has(t.name)) {
                 throw new Error(`Tool "${t.name}" is already registered`);
             }
-            tools.set(t.name, t);
+            tools.set(t.name, t as CoiTool);
         },
         has(name) {
             return tools.has(name);
@@ -56,24 +91,42 @@ export function createToolRegistry(): ToolRegistry {
         list(filter) {
             return filtered(filter);
         },
-        toAiSdkTools(filter) {
+        toAiSdkTools(options) {
+            const { permissionBroker, ...filter } = options ?? {};
             const out: ToolSet = {};
             for (const t of filtered(filter)) {
                 out[t.name] = aiTool({
                     description: t.description,
                     inputSchema: t.inputSchema as never,
-                    needsApproval: t.requiresApproval,
                     execute: (async (
                         input: unknown,
                         opts: {
                             toolCallId: string;
                             abortSignal?: AbortSignal;
                         },
-                    ) =>
-                        t.execute(input as never, {
+                    ) => {
+                        if (t.requiresApproval && permissionBroker) {
+                            const decision =
+                                await permissionBroker.requestApproval({
+                                    toolCallId: opts.toolCallId,
+                                    toolName: t.name,
+                                    input,
+                                });
+                            if (decision === "deny") {
+                                throw new ToolApprovalDeniedError(t.name);
+                            }
+                        }
+                        if (!dependencies) {
+                            throw new Error(
+                                `Tool "${t.name}" requires a registry with dependencies (app, plugin)`,
+                            );
+                        }
+                        return t.execute(input as never, {
+                            ...dependencies,
                             toolCallId: opts.toolCallId,
                             abortSignal: opts.abortSignal,
-                        })) as never,
+                        });
+                    }) as never,
                 });
             }
             return out;

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -1,0 +1,28 @@
+import { Platform } from "obsidian";
+
+import { createToolRegistry, type ToolRegistry } from "@/agent/tool-registry";
+import type { ToolDependencies, ToolPlatform } from "@/agent/types";
+
+import { readNoteTool } from "@/agent/tools/vault/read_note";
+
+/**
+ * Returns the runtime platform tag passed to the registry's platform filter,
+ * so mobile builds skip tools that aren't safe there.
+ */
+export function currentPlatform(): ToolPlatform {
+    return Platform.isMobile ? "mobile" : "desktop";
+}
+
+/**
+ * Builds the default Co-Intelligence tool registry and registers the
+ * first-party tools. Called once at plugin load (`onload`). Phase 3 starts
+ * with the read-only vertical slice (`read_note`); the rest of the vault and
+ * web tools land in subsequent PRs (#42-#50).
+ */
+export function createDefaultToolRegistry(
+    dependencies: ToolDependencies,
+): ToolRegistry {
+    const registry = createToolRegistry(dependencies);
+    registry.register(readNoteTool);
+    return registry;
+}

--- a/src/agent/tools/vault/__tests__/read_note.test.ts
+++ b/src/agent/tools/vault/__tests__/read_note.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { App, TFile, TFolder } from "obsidian";
+
+import { readNoteTool } from "@/agent/tools/vault/read_note";
+import type CoIntelligencePlugin from "@/CoIntelligencePlugin";
+import type { ToolExecutionContext } from "@/agent/types";
+
+function makeApp(overrides: {
+    getAbstractFileByPath: (path: string) => unknown;
+    cachedRead?: (file: TFile) => Promise<string>;
+}): App {
+    const app = new App();
+    app.vault.getAbstractFileByPath = vi
+        .fn()
+        .mockImplementation(overrides.getAbstractFileByPath);
+    if (overrides.cachedRead) {
+        app.vault.cachedRead = vi.fn().mockImplementation(overrides.cachedRead);
+    }
+    return app;
+}
+
+function makeCtx(app: App): ToolExecutionContext {
+    return {
+        app,
+        plugin: {} as CoIntelligencePlugin,
+        toolCallId: "call-1",
+    };
+}
+
+describe("readNoteTool", () => {
+    it("is read-only with vault scope on both platforms", () => {
+        expect(readNoteTool.requiresApproval).toBe(false);
+        expect(readNoteTool.scope).toBe("vault");
+        expect(readNoteTool.platforms).toEqual(["desktop", "mobile"]);
+    });
+
+    it("returns the cached content for an existing note", async () => {
+        const file = new TFile();
+        file.path = "Notes/hello.md";
+        const app = makeApp({
+            getAbstractFileByPath: () => file,
+            cachedRead: async () => "# hello\nworld",
+        });
+        const out = await readNoteTool.execute(
+            { path: "Notes/hello.md" },
+            makeCtx(app),
+        );
+        expect(out).toEqual({
+            path: "Notes/hello.md",
+            content: "# hello\nworld",
+        });
+    });
+
+    it("normalizes the path before lookup", async () => {
+        const file = new TFile();
+        const app = makeApp({
+            getAbstractFileByPath: () => file,
+            cachedRead: async () => "",
+        });
+        await readNoteTool.execute({ path: "Notes//hello.md" }, makeCtx(app));
+        expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith(
+            "Notes/hello.md",
+        );
+    });
+
+    it("throws a friendly error when the path does not exist", async () => {
+        const app = makeApp({ getAbstractFileByPath: () => null });
+        await expect(
+            readNoteTool.execute({ path: "missing.md" }, makeCtx(app)),
+        ).rejects.toThrow(/Note not found at "missing.md"/);
+    });
+
+    it("throws when the path refers to a folder", async () => {
+        const folder = new TFolder();
+        const app = makeApp({ getAbstractFileByPath: () => folder });
+        await expect(
+            readNoteTool.execute({ path: "Notes" }, makeCtx(app)),
+        ).rejects.toThrow(/refers to a folder/);
+    });
+
+    it("rejects empty paths at the schema level", () => {
+        const parse = readNoteTool.inputSchema.safeParse({ path: "" });
+        expect(parse.success).toBe(false);
+    });
+});

--- a/src/agent/tools/vault/read_note.ts
+++ b/src/agent/tools/vault/read_note.ts
@@ -1,0 +1,51 @@
+import { TFile, normalizePath } from "obsidian";
+import { z } from "zod";
+
+import type { CoiTool } from "@/agent/types";
+
+const inputSchema = z.object({
+    path: z
+        .string()
+        .min(1, "path is required")
+        .describe(
+            "Vault-relative path to the note, including the `.md` extension (e.g. `Daily/2025-05-25.md`).",
+        ),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface Output {
+    path: string;
+    content: string;
+}
+
+/**
+ * `read_note` — returns the full markdown content of a vault note at the given
+ * path. Read-only; never requires approval. Mobile-safe (Obsidian Vault API).
+ *
+ * Errors thrown here surface as `tool-error` events; the controller writes
+ * them into the session as `tool-result` parts with `isError: true`.
+ */
+export const readNoteTool: CoiTool<Input, Output> = {
+    name: "read_note",
+    description:
+        "Read the full markdown content of a note in the vault. Returns the raw text including frontmatter.",
+    inputSchema,
+    requiresApproval: false,
+    scope: "vault",
+    platforms: ["desktop", "mobile"],
+    async execute({ path }, { app }) {
+        const normalized = normalizePath(path);
+        const file = app.vault.getAbstractFileByPath(normalized);
+        if (!file) {
+            throw new Error(`Note not found at "${normalized}"`);
+        }
+        if (!(file instanceof TFile)) {
+            throw new Error(
+                `Path "${normalized}" refers to a folder, not a note`,
+            );
+        }
+        const content = await app.vault.cachedRead(file);
+        return { path: normalized, content };
+    },
+};

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,14 +1,29 @@
+import type { App } from "obsidian";
 import type { z } from "zod";
+
+import type { CoIntelligencePlugin } from "@/CoIntelligencePlugin";
 
 export type ToolScope = "vault" | "web" | "mcp";
 
 export type ToolPlatform = "desktop" | "mobile";
 
 /**
- * Context passed to a tool's execute function. Will grow over time (app handle,
- * plugin handle, working directory, etc.) — kept minimal for Phase 1.
+ * Dependencies a tool may need: Obsidian app handle for vault tools, plugin
+ * handle for settings access. Bound at registry construction time and merged
+ * into the per-call {@link ToolExecutionContext}, so individual tools don't
+ * re-thread them through every call site.
  */
-export interface ToolExecutionContext {
+export interface ToolDependencies {
+    app: App;
+    plugin: CoIntelligencePlugin;
+}
+
+/**
+ * Context passed to a tool's execute function. The `app` / `plugin` handles
+ * come from {@link ToolDependencies}; `toolCallId` / `abortSignal` come from
+ * the AI SDK execute wrapper for each call.
+ */
+export interface ToolExecutionContext extends ToolDependencies {
     toolCallId: string;
     abortSignal?: AbortSignal;
 }

--- a/src/chat/use-chat-controller.ts
+++ b/src/chat/use-chat-controller.ts
@@ -10,6 +10,10 @@ import {
 } from "@/services/model-service";
 import type { ChatRequest, ContextItems, Model } from "@/types";
 
+import { currentPlatform } from "@/agent/tools";
+import type { PermissionBroker } from "@/agent/permission-broker";
+import type { ToolRegistry } from "@/agent/tool-registry";
+
 import { buildChatRequest } from "@/chat/request-builder";
 import {
     extractMarkdownLinkSources,
@@ -28,6 +32,10 @@ export interface UseChatControllerParams {
     model: Accessor<Model | null>;
     contextItems: Accessor<ContextItems | null>;
     store: SessionStore;
+    /** Optional — when omitted, tool calls are disabled for the controller. */
+    tools?: ToolRegistry;
+    /** Optional — used to gate approval-required tools. */
+    permissionBroker?: PermissionBroker;
     /** Fires after each successful assistant response completes (post sources). */
     onAssistantResponseComplete?: () => void;
 }
@@ -57,6 +65,8 @@ export function useChatController(
         model,
         contextItems,
         store,
+        tools,
+        permissionBroker,
         onAssistantResponseComplete,
     } = params;
 
@@ -109,7 +119,17 @@ export function useChatController(
         const assistantId = store.beginAssistantMessage();
 
         try {
-            const responseStream = generateChatResponse(request, registry);
+            const sdkTools = tools
+                ? tools.toAiSdkTools({
+                      platform: currentPlatform(),
+                      permissionBroker,
+                  })
+                : {};
+            const responseStream = generateChatResponse(
+                request,
+                registry,
+                sdkTools,
+            );
             let isFirstChunk = true;
 
             try {
@@ -123,15 +143,58 @@ export function useChatController(
                         );
                         continue;
                     }
-                    if (event.type !== "text") {
-                        // Tool / approval / finish events: wired in Phase 5.
+                    if (event.type === "text") {
+                        if (isFirstChunk) {
+                            isFirstChunk = false;
+                            setIsProcessing(false);
+                        }
+                        store.appendAssistantText(assistantId, event.text);
                         continue;
                     }
-                    if (isFirstChunk) {
-                        isFirstChunk = false;
-                        setIsProcessing(false);
+                    if (event.type === "tool-call") {
+                        store.addToolCallPart(assistantId, {
+                            type: "tool-call",
+                            toolCallId: event.toolCallId,
+                            toolName: event.toolName,
+                            input: event.input,
+                            status: "running",
+                        });
+                        continue;
                     }
-                    store.appendAssistantText(assistantId, event.text);
+                    if (event.type === "tool-result") {
+                        store.updateToolCallStatus(
+                            assistantId,
+                            event.toolCallId,
+                            "success",
+                        );
+                        store.addToolResultPart(assistantId, {
+                            type: "tool-result",
+                            toolCallId: event.toolCallId,
+                            toolName: event.toolName,
+                            output: event.output,
+                        });
+                        continue;
+                    }
+                    if (event.type === "tool-error") {
+                        store.updateToolCallStatus(
+                            assistantId,
+                            event.toolCallId,
+                            "error",
+                        );
+                        store.addToolResultPart(assistantId, {
+                            type: "tool-result",
+                            toolCallId: event.toolCallId,
+                            toolName: event.toolName,
+                            output:
+                                (event.error as Error)?.message ??
+                                String(event.error),
+                            isError: true,
+                        });
+                        continue;
+                    }
+                    // approval-requested / finish / finish-step /
+                    // tool-input-delta: not surfaced in the session today
+                    // (Phase 5 wires them in).
                 }
             } catch (error) {
                 console.error("Caught error:", error);
@@ -147,10 +210,8 @@ export function useChatController(
             const assistantMessage = store.session.messages.find(
                 (m) => m.id === assistantId,
             );
-            const finalText = assistantMessage
-                ? messageText(assistantMessage)
-                : "";
-            if (finalText === "") {
+            const hasAnyParts = (assistantMessage?.parts.length ?? 0) > 0;
+            if (!hasAnyParts) {
                 store.appendAssistantText(
                     assistantId,
                     "No response received from the model.",

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -94,6 +94,8 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
         model,
         contextItems,
         store: props.store,
+        tools: plugin.tools,
+        permissionBroker: plugin.permissionBroker,
         onAssistantResponseComplete: props.onAssistantResponseComplete,
     });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -514,3 +514,24 @@ li button.coi-add-context-menu-option:focus-visible {
 .coi-settings-cta svg path {
     fill: var(--text-normal);
 }
+
+.coi-approval-desc {
+    margin: 0 0 0.5rem 0;
+    color: var(--text-muted);
+}
+
+.coi-approval-args {
+    max-height: 24rem;
+    overflow: auto;
+    padding: 0.5rem;
+    background: var(--background-secondary);
+    border-radius: var(--radius-s);
+    font-size: var(--font-smaller);
+}
+
+.coi-approval-buttons {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+}

--- a/test/mocks/obsidian.ts
+++ b/test/mocks/obsidian.ts
@@ -296,6 +296,33 @@ export class AbstractInputSuggest<T> {
   close(): void {}
 }
 
+export class Modal {
+  app: App;
+  containerEl = document.createElement("div");
+  modalEl = document.createElement("div");
+  titleEl = document.createElement("div");
+  contentEl = document.createElement("div");
+  shouldRestoreSelection = false;
+
+  constructor(app: App) {
+    this.app = app;
+  }
+
+  open(): void {}
+  close(): void {
+    this.onClose();
+  }
+  onOpen(): void | Promise<void> {}
+  onClose(): void {}
+
+  setTitle(_title: string): this {
+    return this;
+  }
+  setContent(_content: string | DocumentFragment): this {
+    return this;
+  }
+}
+
 export class SuggestModal<T> {
   app: App;
   inputEl = document.createElement("input");
@@ -401,6 +428,22 @@ export function getAllTags(cache: CachedMetadata): string[] | null {
   if (!cache.tags) return null;
   return cache.tags.map((t) => t.tag);
 }
+
+export const Platform = {
+  isDesktop: true,
+  isMobile: false,
+  isDesktopApp: true,
+  isMobileApp: false,
+  isIosApp: false,
+  isAndroidApp: false,
+  isPhone: false,
+  isTablet: false,
+  isMacOS: false,
+  isWin: false,
+  isLinux: true,
+  isSafari: false,
+  resourcePathPrefix: "app://obsidian.md/",
+};
 
 export const requestUrl = vi.fn().mockResolvedValue({ text: "", json: {} });
 


### PR DESCRIPTION
## Summary

First end-to-end Phase 3 slice (per the recommended starting point in `local/agentic-overhaul-plan.md`): validates the registry → loop → permission broker → controller persistence path with `read_note` as the minimal vertical surface.

- **`read_note` tool** (`src/agent/tools/vault/read_note.ts`) — mobile-safe, reads via `Vault.cachedRead`, normalizes paths, throws clean errors for missing notes / folder-paths.
- **Approval gating moves into the registry** (`src/agent/tool-registry.ts`). The execute wrapper now awaits `broker.requestApproval` for `requiresApproval` tools; `deny` throws `ToolApprovalDeniedError`, which the AI SDK surfaces as a `tool-error`. We're not using the SDK's `needsApproval` handoff because it's tied to the UIMessage approval lifecycle and we have our own session model.
- **Interim Obsidian Modal approval prompt** (`src/agent/approval/obsidian-modal-broker.ts`) — a Solid effect over `broker.pending()` spawns a native modal with allow / deny / always. Phase 5 (#66) replaces it with the in-chat ApprovalPrompt card.
- **Plugin lifecycle** — `CoIntelligencePlugin` owns the tool registry, permission broker, and mounted approval modal; teardown on `onunload`.
- **Controller persistence** — `useChatController` passes registered tools to `generateChatResponse` and dispatches `tool-call` / `tool-result` / `tool-error` events into the session store (`addToolCallPart`, `updateToolCallStatus`, `addToolResultPart`). Tool-only responses no longer trip the "No response received" fallback.
- **Mocks** — adds `Modal` and `Platform` to `test/mocks/obsidian.ts`.

Closes #41. Progress on #40.

## Test plan

- [x] `npm run test:run` — 260 passed
- [x] `npm run build` — clean
- [ ] Manual: open a chat, ask the model to read a note via `read_note`, confirm the tool call + result land in the session and persist on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)